### PR TITLE
Create production-ready dockerfile for k8s deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,107 @@
+# Docker 빌드 최적화를 위한 .dockerignore 파일
+
+# Git 관련 파일들
+.git
+.gitignore
+.gitattributes
+.gitmodules
+
+# IDE 및 에디터 설정 파일들
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS 생성 파일들
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Python 관련 임시 파일들
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+venv/
+ENV/
+.env
+.venv/
+pip-log.txt
+pip-delete-this-directory.txt
+
+# 테스트 관련 파일들
+.tox/
+.coverage
+.coverage.*
+.cache
+.pytest_cache/
+nosetests.xml
+coverage.xml
+htmlcov/
+
+# 로그 파일들
+*.log
+logs/
+
+# 문서 관련 파일들
+README.md
+*.md
+docs/
+
+# 설정 및 예시 파일들
+.env.example
+.env.local
+.env.development
+.env.test
+.env.production
+
+# 임시 파일들
+*.tmp
+*.temp
+.tmp/
+temp/
+
+# Docker 관련 파일들 (Dockerfile 제외)
+docker-compose.yml
+docker-compose.yaml
+docker-compose.*.yml
+docker-compose.*.yaml
+
+# CI/CD 관련 파일들
+.github/
+.gitlab-ci.yml
+.travis.yml
+.circleci/
+Jenkinsfile
+
+# 패키지 매니저 잠금 파일들 (의존성 설치는 requirements.txt 사용)
+poetry.lock
+Pipfile.lock
+
+# 백업 파일들
+*.bak
+*.backup
+*.orig
+
+# 데이터 파일들
+*.csv
+*.json
+*.xml
+data/
+datasets/
+
+# 개발 전용 스크립트들
+scripts/
+dev/
+development/
+
+# 테스트 데이터 및 결과물
+test_results/
+test_data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+# 프로덕션 준비 완료된 Dockerfile for k8s 배포
+# Python 3.11 Alpine 기반 이미지 사용 (보안성 및 경량화)
+FROM python:3.11-alpine
+
+# 메타데이터 라벨
+LABEL maintainer="DevOps Team"
+LABEL description="Tableau Slack Daily Report Service"
+LABEL version="1.0"
+
+# 시스템 의존성 설치 (빌드 및 런타임 도구)
+RUN apk add --no-cache \
+    tzdata \
+    curl \
+    bash \
+    && rm -rf /var/cache/apk/*
+
+# 타임존 설정 (Asia/Seoul)
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# 작업 디렉토리 설정 (프로젝트 이름 기반)
+WORKDIR /workspace
+
+# Python 환경 최적화
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONIOENCODING=UTF-8 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# 의존성 파일 복사 및 설치
+COPY requirements.txt .
+
+# pip 업그레이드 및 의존성 설치
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+# 애플리케이션 파일 복사
+COPY slack .
+COPY web_server.py .
+
+# 실행 스크립트 생성
+RUN echo '#!/bin/bash\n\
+set -e\n\
+echo "Starting Tableau Slack Daily Report Service..."\n\
+echo "Environment variables check:"\n\
+echo "- TABLEAU_SERVER_URL: ${TABLEAU_SERVER_URL:-"Not set"}" \n\
+echo "- TABLEAU_SITE_ID: ${TABLEAU_SITE_ID:-"Not set"}" \n\
+echo "- SLACK_TEAM_NAME: ${SLACK_TEAM_NAME:-"Not set"}" \n\
+echo "Starting Flask web server on port 8080..."\n\
+python web_server.py\n\
+' > /workspace/start.sh && chmod +x /workspace/start.sh
+
+# 포트 8080 노출 (k8s manifest 요구사항)
+EXPOSE 8080
+
+# 헬스체크 설정
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD curl -f http://localhost:8080/health || exit 1
+
+# 애플리케이션 실행
+CMD ["/workspace/start.sh"]

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -1,0 +1,216 @@
+# Tableau Slack Daily Report Service - Docker 배포 가이드
+
+## 📋 프로젝트 개요
+
+Tableau 데이터를 Slack으로 자동 전송하는 Python 서비스입니다.
+k8s 환경에서 8080 포트로 실행되며, Flask 웹 서버를 통해 헬스체크 및 수동 실행 기능을 제공합니다.
+
+## 🐳 Docker 정보
+
+### 이미지 정보
+- **Base Image**: `python:3.11-alpine`
+- **Port**: `8080`
+- **WorkDir**: `/workspace`
+- **User**: `root` (nginx 권한 문제 방지)
+
+### 빌드된 파일 구조
+```
+/workspace/
+├── slack                 # 메인 Python 스크립트
+├── web_server.py        # Flask 웹 서버
+├── requirements.txt     # Python 의존성
+└── start.sh            # 실행 스크립트
+```
+
+## 🚀 k8s 배포 요구사항
+
+### 필수 환경 변수
+```yaml
+env:
+  - name: TABLEAU_SERVER_URL
+    value: "https://tableau.kakaocorp.com"
+  - name: TABLEAU_PAT_NAME
+    valueFrom:
+      secretKeyRef:
+        name: tableau-secrets
+        key: pat-name
+  - name: TABLEAU_PAT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: tableau-secrets
+        key: pat-secret
+  - name: TABLEAU_SITE_ID
+    value: "Kakao_Mobility"
+  - name: SLACK_BOT_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: slack-secrets
+        key: bot-token
+  - name: SLACK_CHANNEL
+    valueFrom:
+      secretKeyRef:
+        name: slack-secrets
+        key: channel-id
+  - name: SLACK_TEAM_NAME
+    value: "CX 시너지팀"
+```
+
+### Deployment 설정
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tableau-slack-report
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tableau-slack-report
+  template:
+    metadata:
+      labels:
+        app: tableau-slack-report
+    spec:
+      containers:
+      - name: tableau-slack-report
+        image: your-registry/tableau-slack-report:latest
+        ports:
+        - containerPort: 8080
+        env:
+          # 위의 환경 변수 설정
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+```
+
+### Service 설정
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: tableau-slack-report-service
+spec:
+  selector:
+    app: tableau-slack-report
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+  type: ClusterIP
+```
+
+## 🔧 로컬 테스트
+
+### Docker Compose 사용
+```bash
+# 환경 변수 설정
+export TABLEAU_PAT_NAME="your-pat-name"
+export TABLEAU_PAT_SECRET="your-pat-secret"
+export SLACK_BOT_TOKEN="xoxb-your-token"
+export SLACK_CHANNEL="your-channel-id"
+
+# 서비스 시작
+docker-compose up -d
+
+# 헬스체크
+curl http://localhost:8080/health
+
+# 수동 실행
+curl -X POST http://localhost:8080/trigger
+
+# 로그 확인
+docker-compose logs -f
+```
+
+### 직접 Docker 빌드/실행
+```bash
+# 이미지 빌드
+docker build -t tableau-slack-report .
+
+# 컨테이너 실행
+docker run -d \
+  --name tableau-slack-report \
+  -p 8080:8080 \
+  -e TABLEAU_PAT_NAME="your-pat-name" \
+  -e TABLEAU_PAT_SECRET="your-pat-secret" \
+  -e SLACK_BOT_TOKEN="xoxb-your-token" \
+  -e SLACK_CHANNEL="your-channel-id" \
+  tableau-slack-report
+```
+
+## 🔍 API 엔드포인트
+
+| 엔드포인트 | 메서드 | 설명 |
+|-----------|--------|------|
+| `/health` | GET | k8s 헬스체크 (환경 변수 검증 포함) |
+| `/status` | GET | 서비스 상태 및 메트릭 |
+| `/trigger` | POST | 수동 리포트 실행 |
+| `/` | GET | 서비스 정보 |
+
+### 헬스체크 응답 예시
+```json
+{
+  "status": "healthy",
+  "timestamp": "2024-01-15T10:30:00.000Z",
+  "service": "tableau-slack-report"
+}
+```
+
+## 🛠 트러블슈팅
+
+### 일반적인 문제들
+
+1. **환경 변수 누락**
+   ```bash
+   # 헬스체크 실패 시 확인
+   curl http://localhost:8080/health
+   # 응답에서 missing environment variables 확인
+   ```
+
+2. **Tableau 연결 실패**
+   ```bash
+   # 상태 확인
+   curl http://localhost:8080/status
+   # last_execution_status 확인
+   ```
+
+3. **Slack 전송 실패**
+   ```bash
+   # 로그 확인
+   docker logs tableau-slack-report
+   ```
+
+### 로그 확인 방법
+```bash
+# Docker Compose
+docker-compose logs -f tableau-slack-report
+
+# 직접 실행
+docker logs -f tableau-slack-report
+
+# k8s
+kubectl logs -f deployment/tableau-slack-report
+```
+
+## 📝 주의사항
+
+1. **환경 변수 보안**: 민감한 정보는 반드시 k8s Secret으로 관리
+2. **네트워크 접근**: Tableau 서버와 Slack API에 대한 아웃바운드 접근 필요
+3. **타임존**: 컨테이너는 Asia/Seoul 타임존으로 설정됨
+4. **로그 수집**: 표준 출력으로 로그 출력하므로 k8s 로그 수집 가능
+
+## 📞 지원
+
+이슈 발생 시 다음 정보와 함께 문의:
+- 컨테이너 로그
+- `/status` 엔드포인트 응답
+- 환경 변수 설정 상태 (민감한 정보 제외)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+# 로컬 테스트용 Docker Compose 파일
+# 프로덕션 배포는 k8s에서 진행됩니다.
+
+version: '3.8'
+
+services:
+  tableau-slack-report:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: tableau-slack-report-local
+    ports:
+      - "8080:8080"
+    environment:
+      # 필수 환경 변수 (실제 값은 .env 파일이나 환경에서 설정)
+      - TABLEAU_SERVER_URL=${TABLEAU_SERVER_URL:-https://tableau.example.com}
+      - TABLEAU_PAT_NAME=${TABLEAU_PAT_NAME:-your_pat_name}
+      - TABLEAU_PAT_SECRET=${TABLEAU_PAT_SECRET:-your_pat_secret}
+      - TABLEAU_SITE_ID=${TABLEAU_SITE_ID:-Default}
+      - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN:-xoxb-your-slack-bot-token}
+      - SLACK_CHANNEL=${SLACK_CHANNEL:-your-channel-id}
+      - SLACK_TEAM_NAME=${SLACK_TEAM_NAME:-Your Team Name}
+      # 타임존 설정
+      - TZ=Asia/Seoul
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    labels:
+      - "traefik.enable=false"
+      - "com.docker.compose.project=tableau-slack-report"
+    networks:
+      - tableau-network
+
+networks:
+  tableau-network:
+    driver: bridge
+    name: tableau-slack-network
+
+# 사용법:
+# 1. 환경 변수 설정 (.env 파일 생성 또는 export)
+# 2. docker-compose up -d
+# 3. 서비스 확인: curl http://localhost:8080/health
+# 4. 수동 실행: curl -X POST http://localhost:8080/trigger
+# 5. 상태 확인: curl http://localhost:8080/status

--- a/web_server.py
+++ b/web_server.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Flask Web Server for k8s Deployment
+Tableau Slack Daily Report Service
+
+This web server provides:
+- Health check endpoint (/health)
+- Status endpoint (/status) 
+- Manual trigger endpoint (/trigger)
+- Root endpoint (/) with service information
+"""
+
+from flask import Flask, jsonify, request
+import os
+import sys
+import threading
+import time
+from datetime import datetime
+import subprocess
+import logging
+
+# 로깅 설정
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+# Flask 앱 생성
+app = Flask(__name__)
+
+# 서비스 상태 관리
+service_status = {
+    "status": "healthy",
+    "last_execution": None,
+    "last_execution_status": None,
+    "uptime_start": datetime.now().isoformat(),
+    "version": "1.0.0"
+}
+
+def run_slack_script():
+    """메인 Slack 스크립트 실행"""
+    try:
+        logger.info("Executing slack script...")
+        result = subprocess.run(
+            [sys.executable, "slack"],
+            capture_output=True,
+            text=True,
+            timeout=300  # 5분 타임아웃
+        )
+        
+        service_status["last_execution"] = datetime.now().isoformat()
+        
+        if result.returncode == 0:
+            service_status["last_execution_status"] = "success"
+            logger.info("Slack script executed successfully")
+        else:
+            service_status["last_execution_status"] = "error"
+            logger.error(f"Slack script failed: {result.stderr}")
+            
+        return result.returncode == 0
+        
+    except subprocess.TimeoutExpired:
+        service_status["last_execution"] = datetime.now().isoformat()
+        service_status["last_execution_status"] = "timeout"
+        logger.error("Slack script execution timed out")
+        return False
+    except Exception as e:
+        service_status["last_execution"] = datetime.now().isoformat()
+        service_status["last_execution_status"] = "error"
+        logger.error(f"Error executing slack script: {str(e)}")
+        return False
+
+@app.route('/health', methods=['GET'])
+def health_check():
+    """k8s 헬스체크 엔드포인트"""
+    try:
+        # 환경 변수 체크
+        required_vars = ['TABLEAU_PAT_NAME', 'TABLEAU_PAT_SECRET', 'SLACK_BOT_TOKEN', 'SLACK_CHANNEL']
+        missing_vars = [var for var in required_vars if not os.environ.get(var)]
+        
+        if missing_vars:
+            return jsonify({
+                "status": "unhealthy",
+                "error": f"Missing environment variables: {', '.join(missing_vars)}",
+                "timestamp": datetime.now().isoformat()
+            }), 503
+            
+        return jsonify({
+            "status": "healthy",
+            "timestamp": datetime.now().isoformat(),
+            "service": "tableau-slack-report"
+        }), 200
+        
+    except Exception as e:
+        return jsonify({
+            "status": "unhealthy",
+            "error": str(e),
+            "timestamp": datetime.now().isoformat()
+        }), 503
+
+@app.route('/status', methods=['GET'])
+def status():
+    """서비스 상태 확인 엔드포인트"""
+    uptime = datetime.now() - datetime.fromisoformat(service_status["uptime_start"])
+    
+    return jsonify({
+        **service_status,
+        "uptime_seconds": int(uptime.total_seconds()),
+        "environment_variables": {
+            "TABLEAU_SERVER_URL": os.environ.get('TABLEAU_SERVER_URL', 'Not set'),
+            "TABLEAU_SITE_ID": os.environ.get('TABLEAU_SITE_ID', 'Not set'),
+            "SLACK_TEAM_NAME": os.environ.get('SLACK_TEAM_NAME', 'Not set'),
+            "required_vars_set": len([var for var in ['TABLEAU_PAT_NAME', 'TABLEAU_PAT_SECRET', 'SLACK_BOT_TOKEN', 'SLACK_CHANNEL'] if os.environ.get(var)])
+        }
+    }), 200
+
+@app.route('/trigger', methods=['POST'])
+def trigger_report():
+    """수동으로 리포트 실행 트리거"""
+    try:
+        logger.info("Manual trigger requested")
+        success = run_slack_script()
+        
+        if success:
+            return jsonify({
+                "status": "success",
+                "message": "Report executed successfully",
+                "timestamp": datetime.now().isoformat()
+            }), 200
+        else:
+            return jsonify({
+                "status": "error",
+                "message": "Report execution failed",
+                "timestamp": datetime.now().isoformat()
+            }), 500
+            
+    except Exception as e:
+        return jsonify({
+            "status": "error",
+            "message": str(e),
+            "timestamp": datetime.now().isoformat()
+        }), 500
+
+@app.route('/', methods=['GET'])
+def root():
+    """루트 엔드포인트 - 서비스 정보"""
+    return jsonify({
+        "service": "Tableau Slack Daily Report Service",
+        "version": "1.0.0",
+        "description": "Automated daily report service for Tableau data to Slack",
+        "endpoints": {
+            "/health": "Health check for k8s",
+            "/status": "Service status and metrics",
+            "/trigger": "Manual report trigger (POST)",
+            "/": "Service information"
+        },
+        "timestamp": datetime.now().isoformat()
+    }), 200
+
+@app.errorhandler(404)
+def not_found(error):
+    """404 에러 핸들러"""
+    return jsonify({
+        "error": "Not Found",
+        "message": "The requested endpoint does not exist",
+        "available_endpoints": ["/", "/health", "/status", "/trigger"],
+        "timestamp": datetime.now().isoformat()
+    }), 404
+
+@app.errorhandler(500)
+def internal_error(error):
+    """500 에러 핸들러"""
+    return jsonify({
+        "error": "Internal Server Error",
+        "message": "An unexpected error occurred",
+        "timestamp": datetime.now().isoformat()
+    }), 500
+
+def scheduled_task():
+    """백그라운드에서 실행되는 스케줄된 작업 (필요시 활성화)"""
+    # 현재는 수동 실행만 지원하지만, 필요시 여기에 스케줄링 로직 추가 가능
+    pass
+
+if __name__ == '__main__':
+    # 환경 변수 확인
+    required_vars = ['TABLEAU_PAT_NAME', 'TABLEAU_PAT_SECRET', 'SLACK_BOT_TOKEN', 'SLACK_CHANNEL']
+    missing_vars = [var for var in required_vars if not os.environ.get(var)]
+    
+    if missing_vars:
+        logger.warning(f"Missing environment variables: {', '.join(missing_vars)}")
+        logger.warning("Service will start but may not function properly until variables are set")
+    
+    logger.info("Starting Tableau Slack Daily Report Web Server...")
+    logger.info(f"Server will be available at http://0.0.0.0:8080")
+    logger.info(f"Health check endpoint: http://0.0.0.0:8080/health")
+    
+    # Flask 앱 실행 (k8s 환경에 맞게 8080 포트, 모든 인터페이스에서 접근 가능)
+    app.run(
+        host='0.0.0.0',
+        port=8080,
+        debug=False,
+        threaded=True
+    )


### PR DESCRIPTION
Add production-ready Dockerfile and a Flask web server to enable Kubernetes deployment of the Tableau Slack Daily Report service.

The core application is a Python script, not a web server. To meet Kubernetes requirements for a service running on port 8080 with health checks, a lightweight Flask web server (`web_server.py`) was introduced. This setup ensures compatibility with fixed K8s manifests, provides essential monitoring endpoints, and addresses common container permission issues by running as root.

---

[Open in Web](https://cursor.com/agents?id=bc-5b2e05e9-25a6-4d76-a6c6-26a821148ae9) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5b2e05e9-25a6-4d76-a6c6-26a821148ae9) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)