### PR TITLE
Create production-ready dockerfile for k8s deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 # Python 3.11 Alpine 기반 이미지 사용 (보안성 및 경량화)
 FROM python:3.11-alpine
 
+# 빌드 인수 (캐시 무효화용)
+ARG CACHEBUST=1
+
 # 메타데이터 라벨
 LABEL maintainer="DevOps Team"
 LABEL description="Tableau Slack Daily Report Service"
@@ -28,8 +31,11 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1
 
+# 캐시 무효화를 위한 더미 명령
+RUN echo "Cache bust: $(date)" > /tmp/cachebust
+
 # 의존성 파일 복사 및 설치
-COPY requirements.txt .
+COPY requirements.txt ./requirements.txt
 
 # pip 업그레이드 및 의존성 설치
 RUN pip install --upgrade pip && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-requests
-slack-sdk
-schedule
-pytz
-Flask
+requests==2.31.0
+slack-sdk==3.27.1
+schedule==1.2.0
+pytz==2023.3
+Flask==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-requirements.txt
-
 requests
 slack-sdk
 schedule


### PR DESCRIPTION
Add production-ready Dockerfile and a Flask web server to enable Kubernetes deployment for the Python script, and fix a `requirements.txt` build error.

This PR introduces a `Dockerfile` and `web_server.py` to containerize the Python script for Kubernetes. The `web_server.py` provides a Flask application on port 8080 for K8s health checks and manual trigger endpoints, addressing the K8s manifest requirements. Additionally, a build error where `pip install -r requirements.txt` failed due to an extraneous "requirements.txt" entry in the file has been resolved.

---

[Open in Web](https://cursor.com/agents?id=bc-5b2e05e9-25a6-4d76-a6c6-26a821148ae9) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5b2e05e9-25a6-4d76-a6c6-26a821148ae9) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)